### PR TITLE
Ensure kind and apiversion

### DIFF
--- a/api/grpc/health/v1/health.pb.go
+++ b/api/grpc/health/v1/health.pb.go
@@ -136,7 +136,9 @@ func init() {
 	proto.RegisterType((*HealthCheckResponse)(nil), "grpc.health.v1.HealthCheckResponse")
 }
 
-func init() { proto.RegisterFile("grpc/health/v1/health.proto", fileDescriptor_e265fd9d4e077217) }
+func init() {
+	proto.RegisterFile("grpc/health/v1/health.proto", fileDescriptor_e265fd9d4e077217)
+}
 
 var fileDescriptor_e265fd9d4e077217 = []byte{
 	// 226 bytes of a gzipped FileDescriptorProto

--- a/api/v1/iam.pb.go
+++ b/api/v1/iam.pb.go
@@ -415,7 +415,9 @@ func init() {
 	proto.RegisterType((*ConnectorConfig)(nil), "v1.ConnectorConfig")
 }
 
-func init() { proto.RegisterFile("v1/iam.proto", fileDescriptor_d513d8b3129389cd) }
+func init() {
+	proto.RegisterFile("v1/iam.proto", fileDescriptor_d513d8b3129389cd)
+}
 
 var fileDescriptor_d513d8b3129389cd = []byte{
 	// 683 bytes of a gzipped FileDescriptorProto

--- a/api/v1/meta.pb.go
+++ b/api/v1/meta.pb.go
@@ -121,7 +121,9 @@ func init() {
 	proto.RegisterMapType((map[string]string)(nil), "v1.Meta.AnnotationsEntry")
 }
 
-func init() { proto.RegisterFile("v1/meta.proto", fileDescriptor_3644ca97b32f0c15) }
+func init() {
+	proto.RegisterFile("v1/meta.proto", fileDescriptor_3644ca97b32f0c15)
+}
 
 var fileDescriptor_3644ca97b32f0c15 = []byte{
 	// 278 bytes of a gzipped FileDescriptorProto

--- a/api/v1/project.pb.go
+++ b/api/v1/project.pb.go
@@ -405,7 +405,9 @@ func init() {
 	proto.RegisterType((*ProjectListResponse)(nil), "v1.ProjectListResponse")
 }
 
-func init() { proto.RegisterFile("v1/project.proto", fileDescriptor_37dd3eae429dd876) }
+func init() {
+	proto.RegisterFile("v1/project.proto", fileDescriptor_37dd3eae429dd876)
+}
 
 var fileDescriptor_37dd3eae429dd876 = []byte{
 	// 452 bytes of a gzipped FileDescriptorProto

--- a/api/v1/project_scnrvalr.go
+++ b/api/v1/project_scnrvalr.go
@@ -31,6 +31,10 @@ func (m Project) Kind() string {
 	return "Project"
 }
 
+func (m Project) APIVersion() string {
+	return "v1"
+}
+
 // Value make the Project struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
 func (m Project) Value() (driver.Value, error) {

--- a/api/v1/project_scnrvalr.go
+++ b/api/v1/project_scnrvalr.go
@@ -27,6 +27,10 @@ func (m Project) TableName() string {
 	return "projects"
 }
 
+func (m Project) Kind() string {
+	return "Project"
+}
+
 // Value make the Project struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
 func (m Project) Value() (driver.Value, error) {

--- a/api/v1/quota.pb.go
+++ b/api/v1/quota.pb.go
@@ -138,7 +138,9 @@ func init() {
 	proto.RegisterType((*Quota)(nil), "v1.Quota")
 }
 
-func init() { proto.RegisterFile("v1/quota.proto", fileDescriptor_6fa4cec8749083f6) }
+func init() {
+	proto.RegisterFile("v1/quota.proto", fileDescriptor_6fa4cec8749083f6)
+}
 
 var fileDescriptor_6fa4cec8749083f6 = []byte{
 	// 192 bytes of a gzipped FileDescriptorProto

--- a/api/v1/tenant.pb.go
+++ b/api/v1/tenant.pb.go
@@ -396,7 +396,9 @@ func init() {
 	proto.RegisterType((*TenantListResponse)(nil), "v1.TenantListResponse")
 }
 
-func init() { proto.RegisterFile("v1/tenant.proto", fileDescriptor_941e7e5149062005) }
+func init() {
+	proto.RegisterFile("v1/tenant.proto", fileDescriptor_941e7e5149062005)
+}
 
 var fileDescriptor_941e7e5149062005 = []byte{
 	// 462 bytes of a gzipped FileDescriptorProto

--- a/api/v1/tenant_scnrvalr.go
+++ b/api/v1/tenant_scnrvalr.go
@@ -31,6 +31,10 @@ func (m Tenant) Kind() string {
 	return "Tenant"
 }
 
+func (m Tenant) APIVersion() string {
+	return "v1"
+}
+
 // Value make the Tenant struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
 func (m Tenant) Value() (driver.Value, error) {

--- a/api/v1/tenant_scnrvalr.go
+++ b/api/v1/tenant_scnrvalr.go
@@ -27,6 +27,10 @@ func (m Tenant) TableName() string {
 	return "tenants"
 }
 
+func (m Tenant) Kind() string {
+	return "Tenant"
+}
+
 // Value make the Tenant struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
 func (m Tenant) Value() (driver.Value, error) {

--- a/pkg/datastore/postgres.go
+++ b/pkg/datastore/postgres.go
@@ -19,7 +19,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const desired_apiversion = "v1"
+// TODO this could be done with genscanvaluer.go as well
+const desiredAPIVersion = "v1"
 
 // Storage is a interface to store objects.
 type Storage interface {
@@ -109,10 +110,9 @@ func (ds *Datastore) Create(ctx context.Context, ve VersionedJSONEntity) error {
 	}
 	apiVersion := meta.GetApiversion()
 	if apiVersion == "" {
-		// TODO this could be done with genscanvaluer.go as well
-		meta.Apiversion = desired_apiversion
-	} else if apiVersion != desired_apiversion {
-		return fmt.Errorf("create of type:%s failed, apiversion must be set to:%s", jsonField, desired_apiversion)
+		meta.Apiversion = desiredAPIVersion
+	} else if apiVersion != desiredAPIVersion {
+		return fmt.Errorf("create of type:%s failed, apiversion must be set to:%s", jsonField, desiredAPIVersion)
 	}
 
 	meta.SetVersion(0)
@@ -173,10 +173,9 @@ func (ds *Datastore) Update(ctx context.Context, ve VersionedJSONEntity) error {
 	}
 	apiVersion := meta.GetApiversion()
 	if apiVersion == "" {
-		// TODO this could be done with genscanvaluer.go as well
-		meta.Apiversion = desired_apiversion
-	} else if apiVersion != desired_apiversion {
-		return fmt.Errorf("update of type:%s failed, apiversion must be set to:%s", jsonField, desired_apiversion)
+		meta.Apiversion = desiredAPIVersion
+	} else if apiVersion != desiredAPIVersion {
+		return fmt.Errorf("update of type:%s failed, apiversion must be set to:%s", jsonField, desiredAPIVersion)
 	}
 
 	elemt := reflect.TypeOf(ve).Elem()

--- a/pkg/datastore/postgres.go
+++ b/pkg/datastore/postgres.go
@@ -3,9 +3,10 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/golang/protobuf/ptypes"
 	"github.com/lib/pq"
-	"reflect"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
@@ -13,9 +14,12 @@ import (
 	v1 "github.com/metal-stack/masterdata-api/api/v1"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
 	// import for sqlx to use postgres driver
 	_ "github.com/lib/pq"
 )
+
+const desired_apiversion = "v1"
 
 // Storage is a interface to store objects.
 type Storage interface {
@@ -37,6 +41,7 @@ type JSONEntity interface {
 // VersionedEntity defines a database entity which is stored with version information
 type VersionedEntity interface {
 	GetMeta() *v1.Meta
+	Kind() string
 }
 
 // VersionedJSONEntity defines a database entity which is stored in jsonb format and with version information
@@ -96,6 +101,19 @@ func (ds *Datastore) Create(ctx context.Context, ve VersionedJSONEntity) error {
 		id = uuid.Must(uuid.NewRandom()).String()
 		meta.SetId(id)
 	}
+	kind := meta.GetKind()
+	if kind == "" {
+		meta.Kind = ve.Kind()
+	} else if kind != ve.Kind() {
+		return fmt.Errorf("create of type:%s failed, kind is set to:%s but must be:%s", jsonField, kind, ve.Kind())
+	}
+	apiVersion := meta.GetApiversion()
+	if apiVersion == "" {
+		// TODO this could be done with genscanvaluer.go as well
+		meta.Apiversion = desired_apiversion
+	} else if apiVersion != desired_apiversion {
+		return fmt.Errorf("create of type:%s failed, apiversion must be set to:%s", jsonField, desired_apiversion)
+	}
 
 	meta.SetVersion(0)
 	meta.SetCreatedTime(ptypes.TimestampNow())
@@ -146,6 +164,19 @@ func (ds *Datastore) Update(ctx context.Context, ve VersionedJSONEntity) error {
 	id := meta.GetId()
 	if id == "" {
 		return fmt.Errorf("entity of type:%s has no id, cannot update: %v", jsonField, ve)
+	}
+	kind := meta.GetKind()
+	if kind == "" {
+		meta.Kind = ve.Kind()
+	} else if kind != ve.Kind() {
+		return fmt.Errorf("update of type:%s failed, kind is set to:%s but must be:%s", jsonField, kind, ve.Kind())
+	}
+	apiVersion := meta.GetApiversion()
+	if apiVersion == "" {
+		// TODO this could be done with genscanvaluer.go as well
+		meta.Apiversion = desired_apiversion
+	} else if apiVersion != desired_apiversion {
+		return fmt.Errorf("update of type:%s failed, apiversion must be set to:%s", jsonField, desired_apiversion)
 	}
 
 	elemt := reflect.TypeOf(ve).Elem()

--- a/pkg/datastore/postgres.go
+++ b/pkg/datastore/postgres.go
@@ -19,9 +19,6 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// TODO this could be done with genscanvaluer.go as well
-const desiredAPIVersion = "v1"
-
 // Storage is a interface to store objects.
 type Storage interface {
 	// generic
@@ -43,6 +40,7 @@ type JSONEntity interface {
 type VersionedEntity interface {
 	GetMeta() *v1.Meta
 	Kind() string
+	APIVersion() string
 }
 
 // VersionedJSONEntity defines a database entity which is stored in jsonb format and with version information
@@ -110,9 +108,9 @@ func (ds *Datastore) Create(ctx context.Context, ve VersionedJSONEntity) error {
 	}
 	apiVersion := meta.GetApiversion()
 	if apiVersion == "" {
-		meta.Apiversion = desiredAPIVersion
-	} else if apiVersion != desiredAPIVersion {
-		return fmt.Errorf("create of type:%s failed, apiversion must be set to:%s", jsonField, desiredAPIVersion)
+		meta.Apiversion = ve.APIVersion()
+	} else if apiVersion != ve.APIVersion() {
+		return fmt.Errorf("create of type:%s failed, apiversion must be set to:%s", jsonField, ve.APIVersion())
 	}
 
 	meta.SetVersion(0)
@@ -173,9 +171,9 @@ func (ds *Datastore) Update(ctx context.Context, ve VersionedJSONEntity) error {
 	}
 	apiVersion := meta.GetApiversion()
 	if apiVersion == "" {
-		meta.Apiversion = desiredAPIVersion
-	} else if apiVersion != desiredAPIVersion {
-		return fmt.Errorf("update of type:%s failed, apiversion must be set to:%s", jsonField, desiredAPIVersion)
+		meta.Apiversion = ve.APIVersion()
+	} else if apiVersion != ve.APIVersion() {
+		return fmt.Errorf("update of type:%s failed, apiversion must be set to:%s", jsonField, ve.APIVersion())
 	}
 
 	elemt := reflect.TypeOf(ve).Elem()

--- a/pkg/datastore/postgres_test.go
+++ b/pkg/datastore/postgres_test.go
@@ -27,6 +27,7 @@ type invalidVersionedEntity struct{}
 func (v *invalidVersionedEntity) JSONField() string { return "invalid" }
 func (v *invalidVersionedEntity) TableName() string { return "" }
 func (v *invalidVersionedEntity) Schema() string    { return "" }
+func (v *invalidVersionedEntity) Kind() string      { return "Invalid" }
 func (v *invalidVersionedEntity) GetMeta() *v1.Meta { return nil }
 
 func TestMain(m *testing.M) {
@@ -279,6 +280,40 @@ func TestCreate(t *testing.T) {
 	assert.Contains(t, tcr3.GetMeta().GetId(), "-")
 	assert.Len(t, tcr3.GetMeta().GetId(), 36)
 
+	// create with empty kind and apiversion
+	tcr4 := &v1.Tenant{
+		Meta:        &v1.Meta{},
+		Name:        "dtenant",
+		Description: "D Tenant",
+	}
+	err = ds.Create(ctx, tcr4)
+	assert.NoError(t, err)
+	assert.NotNil(t, tcr3.GetMeta().GetApiversion())
+	assert.NotEmpty(t, tcr3.GetMeta().GetApiversion())
+	assert.Equal(t, tcr3.GetMeta().GetApiversion(), "v1")
+	assert.NotNil(t, tcr3.GetMeta().GetKind())
+	assert.NotEmpty(t, tcr3.GetMeta().GetKind())
+	assert.Equal(t, tcr3.GetMeta().GetKind(), "Tenant")
+
+	// create with wrong kind
+	tcr5 := &v1.Tenant{
+		Meta:        &v1.Meta{Kind: "Project"},
+		Name:        "etenant",
+		Description: "E Tenant",
+	}
+	err = ds.Create(ctx, tcr5)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "create of type:tenant failed, kind is set to:Project but must be:Tenant")
+
+	// create with wrong apiversion
+	tcr6 := &v1.Tenant{
+		Meta:        &v1.Meta{Apiversion: "v2"},
+		Name:        "ftenant",
+		Description: "F Tenant",
+	}
+	err = ds.Create(ctx, tcr6)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "create of type:tenant failed, apiversion must be set to:v1")
 }
 
 func TestUpdate(t *testing.T) {
@@ -333,6 +368,18 @@ func TestUpdate(t *testing.T) {
 	assert.Equal(t, "ctenant", tcr1.GetName())
 	assert.Equal(t, "C Tenant 3", tcr1.GetDescription())
 
+	// try update with wrong kind
+	tcr1.Meta.Kind = "WrongKind"
+	err = ds.Update(ctx, tcr1)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "update of type:tenant failed, kind is set to:WrongKind but must be:Tenant")
+
+	// try update with wrong kind
+	tcr1.Meta.Kind = "Tenant"
+	tcr1.Meta.Apiversion = "v2"
+	err = ds.Update(ctx, tcr1)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "update of type:tenant failed, apiversion must be set to:v1")
 }
 
 func TestGet(t *testing.T) {

--- a/pkg/datastore/postgres_test.go
+++ b/pkg/datastore/postgres_test.go
@@ -24,11 +24,12 @@ var (
 // to test unregistered type checks
 type invalidVersionedEntity struct{}
 
-func (v *invalidVersionedEntity) JSONField() string { return "invalid" }
-func (v *invalidVersionedEntity) TableName() string { return "" }
-func (v *invalidVersionedEntity) Schema() string    { return "" }
-func (v *invalidVersionedEntity) Kind() string      { return "Invalid" }
-func (v *invalidVersionedEntity) GetMeta() *v1.Meta { return nil }
+func (v *invalidVersionedEntity) JSONField() string  { return "invalid" }
+func (v *invalidVersionedEntity) TableName() string  { return "" }
+func (v *invalidVersionedEntity) Schema() string     { return "" }
+func (v *invalidVersionedEntity) Kind() string       { return "Invalid" }
+func (v *invalidVersionedEntity) APIVersion() string { return "v1" }
+func (v *invalidVersionedEntity) GetMeta() *v1.Meta  { return nil }
 
 func TestMain(m *testing.M) {
 	code := 0

--- a/pkg/gen/genscanvaluer.go
+++ b/pkg/gen/genscanvaluer.go
@@ -103,7 +103,6 @@ func (g *Generator) generate(packageName, typeName string) error {
 		"packageName":   packageName,
 		"typeName":      typeName,
 		"typeNameLower": strings.ToLower(typeName),
-		"kind":          strings.Title(strings.ToLower(typeName)),
 		"tableName":     strings.ToLower(typeName) + "s",
 	}
 
@@ -171,7 +170,7 @@ func (m {{ .typeName }}) TableName() string {
 }
 
 func (m {{ .typeName }}) Kind() string {
-	return "{{ .kind }}"
+	return "{{ .typeName }}"
 }
 
 func (m {{ .typeName }}) APIVersion() string {

--- a/pkg/gen/genscanvaluer.go
+++ b/pkg/gen/genscanvaluer.go
@@ -174,6 +174,10 @@ func (m {{ .typeName }}) Kind() string {
 	return "{{ .kind }}"
 }
 
+func (m {{ .typeName }}) APIVersion() string {
+	return "{{ .packageName }}"
+}
+
 // Value make the {{ .typeName }} struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
 func (m {{ .typeName }}) Value() (driver.Value, error) {

--- a/pkg/gen/genscanvaluer.go
+++ b/pkg/gen/genscanvaluer.go
@@ -13,8 +13,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	errs "github.com/pkg/errors"
-	"go.uber.org/zap"
 	"go/format"
 	"io/ioutil"
 	"log"
@@ -22,6 +20,9 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	errs "github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 const defaultFilenameSuffix = "_scnrvalr.go"
@@ -102,6 +103,7 @@ func (g *Generator) generate(packageName, typeName string) error {
 		"packageName":   packageName,
 		"typeName":      typeName,
 		"typeNameLower": strings.ToLower(typeName),
+		"kind":          strings.Title(strings.ToLower(typeName)),
 		"tableName":     strings.ToLower(typeName) + "s",
 	}
 
@@ -166,6 +168,10 @@ func (m {{ .typeName }}) JSONField() string {
 
 func (m {{ .typeName }}) TableName() string {
 	return "{{ .typeNameLower }}s"
+}
+
+func (m {{ .typeName }}) Kind() string {
+	return "{{ .kind }}"
 }
 
 // Value make the {{ .typeName }} struct implement the driver.Valuer interface. This method


### PR DESCRIPTION
during project and tenant update i stumbled across the fact that kind and apiversion are not set. So ensure they are set if not given and checked for correct content.