### PR TITLE
Add rest API definitions for proper swagger client specs.

### DIFF
--- a/api/rest/README.md
+++ b/api/rest/README.md
@@ -1,0 +1,7 @@
+# TEMPORARY PACKAGE
+
+Currently we do not have a CLI tool to manage projects and tenants in the masterdata-api.
+
+For the time being, we can use the definitions of this package to generate proper swagger clients.
+
+As soon as we have a CLI tool and client authentication, we can probably remove this package and remove managing masterdata entities from the other APIs that use these definitions.

--- a/api/rest/mapper/mapper.go
+++ b/api/rest/mapper/mapper.go
@@ -1,0 +1,199 @@
+package mapper
+
+import (
+	"time"
+
+	px "github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	v1 "github.com/metal-stack/masterdata-api/api/rest/v1"
+	mdmv1 "github.com/metal-stack/masterdata-api/api/v1"
+)
+
+func ToMdmV1Tenant(p *v1.Tenant) *mdmv1.Tenant {
+
+	if p == nil {
+		return nil
+	}
+
+	return &mdmv1.Tenant{
+		Meta:          ToMdmV1Meta(p.Meta),
+		Name:          p.Name,
+		Description:   p.Description,
+		Quotas:        ToMdmV1QuotaSet(p.Quotas),
+		DefaultQuotas: ToMdmV1QuotaSet(p.DefaultQuotas),
+	}
+}
+
+func ToV1Tenant(p *mdmv1.Tenant) *v1.Tenant {
+
+	if p == nil {
+		return nil
+	}
+
+	return &v1.Tenant{
+		Meta:          ToV1Meta(p.Meta),
+		Name:          p.Name,
+		Description:   p.Description,
+		Quotas:        ToV1QuotaSet(p.Quotas),
+		DefaultQuotas: ToV1QuotaSet(p.DefaultQuotas),
+	}
+}
+
+func ToMdmV1Project(p *v1.Project) *mdmv1.Project {
+
+	if p == nil {
+		return nil
+	}
+
+	return &mdmv1.Project{
+		Meta:        ToMdmV1Meta(p.Meta),
+		Name:        p.Name,
+		Description: p.Description,
+		TenantId:    p.TenantId,
+		Quotas:      ToMdmV1QuotaSet(p.Quotas),
+	}
+}
+
+func ToV1Project(p *mdmv1.Project) *v1.Project {
+
+	if p == nil {
+		return nil
+	}
+
+	return &v1.Project{
+		Meta:        ToV1Meta(p.Meta),
+		Name:        p.Name,
+		Description: p.Description,
+		TenantId:    p.TenantId,
+		Quotas:      ToV1QuotaSet(p.Quotas),
+	}
+}
+
+func ToMdmV1QuotaSet(qs *v1.QuotaSet) *mdmv1.QuotaSet {
+
+	if qs == nil {
+		return nil
+	}
+
+	return &mdmv1.QuotaSet{
+		Cluster: ToMdmV1Quota(qs.Cluster),
+		Machine: ToMdmV1Quota(qs.Machine),
+		Ip:      ToMdmV1Quota(qs.Ip),
+	}
+}
+
+func ToMdmV1Quota(q *v1.Quota) *mdmv1.Quota {
+
+	if q == nil {
+		return nil
+	}
+	if q.Quota == nil {
+		return nil
+	}
+
+	return &mdmv1.Quota{
+		Quota: &wrappers.Int32Value{
+			Value: *q.Quota,
+		},
+	}
+}
+
+func ToMdmV1Meta(m *v1.Meta) *mdmv1.Meta {
+
+	if m == nil {
+		return nil
+	}
+
+	return &mdmv1.Meta{
+		Id:          m.Id,
+		Kind:        m.Kind,
+		Apiversion:  m.Apiversion,
+		Version:     m.Version,
+		CreatedTime: mustTimeToTimestamp(m.CreatedTime),
+		UpdatedTime: mustTimeToTimestamp(m.UpdatedTime),
+		Annotations: m.Annotations,
+		Labels:      m.Labels,
+	}
+}
+
+func ToV1Meta(m *mdmv1.Meta) *v1.Meta {
+
+	if m == nil {
+		return nil
+	}
+
+	return &v1.Meta{
+		Id:          m.Id,
+		Kind:        m.Kind,
+		Apiversion:  m.Apiversion,
+		Version:     m.Version,
+		CreatedTime: mustTimestampToTime(m.CreatedTime),
+		UpdatedTime: mustTimestampToTime(m.UpdatedTime),
+		Annotations: m.Annotations,
+		Labels:      m.Labels,
+	}
+}
+
+func ToV1QuotaSet(q *mdmv1.QuotaSet) *v1.QuotaSet {
+
+	if q == nil {
+		return nil
+	}
+	return &v1.QuotaSet{
+		Cluster: ToV1Quota(q.Cluster),
+		Machine: ToV1Quota(q.Machine),
+		Ip:      ToV1Quota(q.Ip),
+		Project: ToV1Quota(q.Project),
+	}
+}
+
+func ToV1Quota(q *mdmv1.Quota) *v1.Quota {
+	if q == nil {
+		return nil
+	}
+	return &v1.Quota{
+		Quota: unwrapInt32(q.Quota),
+	}
+}
+
+func unwrapInt32(w *wrappers.Int32Value) *int32 {
+	if w == nil {
+		return nil
+	}
+
+	return &w.Value
+}
+
+func mustTimestampToTime(ts *timestamp.Timestamp) *time.Time {
+	t, err := timestampToTime(ts)
+	if err != nil {
+		t = nil
+	}
+	return t
+}
+
+func timestampToTime(ts *timestamp.Timestamp) (*time.Time, error) {
+	if ts == nil {
+		return nil, nil
+	}
+
+	t, err := px.Timestamp(ts)
+	return &t, err
+}
+
+func mustTimeToTimestamp(t *time.Time) *timestamp.Timestamp {
+	ts, err := timeToTimestamp(t)
+	if err != nil {
+		ts = nil
+	}
+	return ts
+}
+
+func timeToTimestamp(t *time.Time) (*timestamp.Timestamp, error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	return px.TimestampProto(*t)
+}

--- a/api/rest/mapper/mapper.go
+++ b/api/rest/mapper/mapper.go
@@ -8,10 +8,10 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	v1 "github.com/metal-stack/masterdata-api/api/rest/v1"
 	mdmv1 "github.com/metal-stack/masterdata-api/api/v1"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func ToMdmV1Tenant(p *v1.Tenant) *mdmv1.Tenant {
-
 	if p == nil {
 		return nil
 	}
@@ -26,7 +26,6 @@ func ToMdmV1Tenant(p *v1.Tenant) *mdmv1.Tenant {
 }
 
 func ToV1Tenant(p *mdmv1.Tenant) *v1.Tenant {
-
 	if p == nil {
 		return nil
 	}
@@ -41,7 +40,6 @@ func ToV1Tenant(p *mdmv1.Tenant) *v1.Tenant {
 }
 
 func ToMdmV1Project(p *v1.Project) *mdmv1.Project {
-
 	if p == nil {
 		return nil
 	}
@@ -56,7 +54,6 @@ func ToMdmV1Project(p *v1.Project) *mdmv1.Project {
 }
 
 func ToV1Project(p *mdmv1.Project) *v1.Project {
-
 	if p == nil {
 		return nil
 	}
@@ -71,7 +68,6 @@ func ToV1Project(p *mdmv1.Project) *v1.Project {
 }
 
 func ToMdmV1QuotaSet(qs *v1.QuotaSet) *mdmv1.QuotaSet {
-
 	if qs == nil {
 		return nil
 	}
@@ -84,7 +80,6 @@ func ToMdmV1QuotaSet(qs *v1.QuotaSet) *mdmv1.QuotaSet {
 }
 
 func ToMdmV1Quota(q *v1.Quota) *mdmv1.Quota {
-
 	if q == nil {
 		return nil
 	}
@@ -100,7 +95,6 @@ func ToMdmV1Quota(q *v1.Quota) *mdmv1.Quota {
 }
 
 func ToMdmV1Meta(m *v1.Meta) *mdmv1.Meta {
-
 	if m == nil {
 		return nil
 	}
@@ -117,8 +111,29 @@ func ToMdmV1Meta(m *v1.Meta) *mdmv1.Meta {
 	}
 }
 
-func ToV1Meta(m *mdmv1.Meta) *v1.Meta {
+func ToMdmV1ProjectFindRequest(r *v1.ProjectFindRequest) *mdmv1.ProjectFindRequest {
+	if r == nil {
+		return nil
+	}
 
+	mdmv1r := new(mdmv1.ProjectFindRequest)
+	if r.Id != nil {
+		mdmv1r.Id = &wrapperspb.StringValue{Value: *r.Id}
+	}
+	if r.Description != nil {
+		mdmv1r.Description = &wrapperspb.StringValue{Value: *r.Description}
+	}
+	if r.Name != nil {
+		mdmv1r.Name = &wrapperspb.StringValue{Value: *r.Name}
+	}
+	if r.TenantId != nil {
+		mdmv1r.Id = &wrapperspb.StringValue{Value: *r.TenantId}
+	}
+
+	return mdmv1r
+}
+
+func ToV1Meta(m *mdmv1.Meta) *v1.Meta {
 	if m == nil {
 		return nil
 	}
@@ -136,7 +151,6 @@ func ToV1Meta(m *mdmv1.Meta) *v1.Meta {
 }
 
 func ToV1QuotaSet(q *mdmv1.QuotaSet) *v1.QuotaSet {
-
 	if q == nil {
 		return nil
 	}
@@ -156,7 +170,6 @@ func ToV1Quota(q *mdmv1.Quota) *v1.Quota {
 		Quota: unwrapInt32(q.Quota),
 	}
 }
-
 func unwrapInt32(w *wrappers.Int32Value) *int32 {
 	if w == nil {
 		return nil

--- a/api/rest/v1/masterdata.go
+++ b/api/rest/v1/masterdata.go
@@ -1,0 +1,89 @@
+package v1
+
+import (
+	"errors"
+	"reflect"
+	"time"
+)
+
+type QuotaSet struct {
+	Cluster *Quota `json:"cluster,omitempty"`
+	Machine *Quota `json:"machine,omitempty"`
+	Ip      *Quota `json:"ip,omitempty"`
+	Project *Quota `json:"project,omitempty"`
+}
+
+type Quota struct {
+	Used  *int32 `json:"used,omitempty"`
+	Quota *int32 `json:"quota,omitempty"`
+}
+
+type Meta struct {
+	Id          string            `json:"id,omitempty"`
+	Kind        string            `json:"kind,omitempty"`
+	Apiversion  string            `json:"apiversion,omitempty"`
+	Version     int64             `json:"version,omitempty"`
+	CreatedTime *time.Time        `json:"created_time,omitempty"`
+	UpdatedTime *time.Time        `json:"updated_time,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      []string          `json:"labels,omitempty"`
+}
+
+type (
+	ProjectIDTime struct {
+		ProjectID string    `json:"project_id,omitempty" description:"projectID as returned by cloud-api (e.g. 10241dd7-a8de-4856-8ac0-b55830b22036)"`
+		Time      time.Time `json:"time,omitempty" description:"point in time"`
+	}
+
+	// cluster-identification e.g. from prometheus-metrics
+	ClusterNameProject struct {
+		ClusterName string `json:"cluster_name,omitempty" description:"cluster name"`
+		Project     string `json:"project,omitempty" description:"generated middle-part of gardener shoot namespace, e.g. 'ps5d42'"`
+	}
+
+	// MasterdataLookupRequest to specify which masterdata tenant and project to return
+	MasterdataLookupRequest struct {
+		// search by name and project
+		ClusterNameProject *ClusterNameProject `json:"cluster_name_project,omitempty" description:"lookup by clustername and shoot-project"`
+
+		// OR search by ClusterID as returned by cloud-api (e.g. 345abc12-3321-4dbc-8d17-55c6ea4fcb38)
+		ClusterID *string `json:"cluster_id,omitempty" description:"lookup by clusterID as returned by cloud-api (e.g. 345abc12-3321-4dbc-8d17-55c6ea4fcb38)"`
+
+		// OR search by ProjectID as returned by cloud-api (e.g. 10241dd7-a8de-4856-8ac0-b55830b22036) at some point in time
+		ProjectIDTime *ProjectIDTime `json:"project_id_time,omitempty" description:"lookup at some point in time by projectID as returned by cloud-api (e.g. 10241dd7-a8de-4856-8ac0-b55830b22036)"`
+	}
+
+	// MasterdataLookupResponse contains the masterdata tenant and project
+	MasterdataLookupResponse struct {
+		Tenant  *Tenant  `json:"tenant,omitempty" description:"tenant to which the project belongs"`
+		Project *Project `json:"project,omitempty" description:"project"`
+	}
+)
+
+// Validate validates the request.
+func (mlr *MasterdataLookupRequest) Validate() error {
+	if mlr == nil {
+		return errors.New("masterdataLookupRequest is nil")
+	}
+	if mlr.ClusterID == nil && mlr.ClusterNameProject == nil && mlr.ProjectIDTime == nil {
+		return errors.New("one of ClusterNameProject, ClusterID or ProjectID must be set")
+	}
+	if !onlyOneOfPtrsSet(mlr.ClusterID, mlr.ClusterNameProject, mlr.ProjectIDTime) {
+		return errors.New("only one of ClusterNameProject, ClusterID or ProjectIDTime may be set")
+	}
+
+	return nil
+}
+
+// onlyOneOfPtrsSet returns true if only one of the given pointers is not nil.
+// If values are given they are always counted as not nil.
+func onlyOneOfPtrsSet(ptrs ...interface{}) bool {
+	count := 0
+	for _, p := range ptrs {
+		rv := reflect.ValueOf(p)
+		if rv.Kind() != reflect.Ptr || !rv.IsNil() {
+			count++
+		}
+	}
+	return count == 1
+}

--- a/api/rest/v1/project.go
+++ b/api/rest/v1/project.go
@@ -1,0 +1,27 @@
+package v1
+
+type (
+	Project struct {
+		Meta        *Meta     `json:"meta,omitempty"`
+		Name        string    `json:"name,omitempty"`
+		Description string    `json:"description,omitempty"`
+		TenantId    string    `json:"tenant_id,omitempty"`
+		Quotas      *QuotaSet `json:"quotas,omitempty"`
+	}
+
+	ProjectCreateRequest struct {
+		Project
+	}
+
+	ProjectUpdateRequest struct {
+		Project
+	}
+
+	ProjectResponse struct {
+		Project
+	}
+
+	ProjectListResponse struct {
+		Projects []*Project `json:"projects,omitempty"`
+	}
+)

--- a/api/rest/v1/project.go
+++ b/api/rest/v1/project.go
@@ -17,6 +17,13 @@ type (
 		Project
 	}
 
+	ProjectFindRequest struct {
+		Id          *string `json:"id,omitempty"`
+		Name        *string `json:"name,omitempty"`
+		Description *string `json:"description,omitempty"`
+		TenantId    *string `json:"tenant_id,omitempty"`
+	}
+
 	ProjectResponse struct {
 		Project
 	}

--- a/api/rest/v1/tenant.go
+++ b/api/rest/v1/tenant.go
@@ -1,0 +1,19 @@
+package v1
+
+type (
+	Tenant struct {
+		Meta          *Meta     `json:"meta,omitempty"`
+		Name          string    `json:"name,omitempty"`
+		Description   string    `json:"description,omitempty"`
+		DefaultQuotas *QuotaSet `json:"default_quotas,omitempty"`
+		Quotas        *QuotaSet `json:"quotas,omitempty"`
+	}
+
+	TenantUpdateRequest struct {
+		Tenant *Tenant `json:"tenant,omitempty"`
+	}
+
+	TenantResponse struct {
+		Tenant *Tenant `json:"tenant,omitempty"`
+	}
+)


### PR DESCRIPTION
Currently we do not have a CLI tool to manage projects and tenants in the masterdata-api.

For the time being, we can use the definitions of this package to generate proper swagger clients.

As soon as we have a CLI tool and client authentication, we can probably remove this package and remove managing masterdata entities from the other APIs that use these definitions.