### PR TITLE
Do not install mockery automatically during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ BUILDDATE := $(shell date -Iseconds)
 VERSION := $(or ${VERSION},devel)
 
 .PHONY: all
-all: protoc generate mocks test server client
+all: protoc generate test server client
 
 .PHONY: release
 release: generate test server client
 
 .PHONY: clean
-clean: 
+clean:
 	rm -f api/v1/*pb.go bin/*
 
 .PHONY: protoc
@@ -54,9 +54,10 @@ client:
 	strip bin/client
 
 .PHONY: mocks
-mocks: mockery
-	cd api/v1 && $(MOCKERY) --name ProjectServiceClient && $(MOCKERY) --name TenantServiceClient && cd -
-	cd pkg/datastore && $(MOCKERY) --name Storage && cd -
+mocks:
+	@if ! which mockery > /dev/null; then echo "mockery needs to be installed (https://github.com/vektra/mockery)"; exit 1; fi
+	cd api/v1 && mockery --name ProjectServiceClient && mockery --name TenantServiceClient && cd -
+	cd pkg/datastore && mockery --name Storage && cd -
 
 .PHONY: postgres-up
 postgres-up: postgres-rm
@@ -71,21 +72,3 @@ certs:
 	cd certs && cfssl gencert -initca ca-csr.json | cfssljson -bare ca -
 	cd certs && cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile client-server server.json | cfssljson -bare server -
 	cd certs && cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile client client.json | cfssljson -bare client -
-
-# find or download mockery
-.PHONY: mockery
-mockery:
-ifeq (, $(shell which mockery))
-	@{ \
-	set -e ;\
-	MOCKERY_TMP_DIR=$$(mktemp -d) ;\
-	cd $$MOCKERY_TMP_DIR ;\
-	wget https://github.com/vektra/mockery/releases/download/v2.0.4/mockery_2.0.4_Linux_x86_64.tar.gz ;\
-	tar -xf mockery_2.0.4_Linux_x86_64.tar.gz ;\
-	mv mockery $(GOBIN)/mockery ;\
-	rm -rf $$MOCKERY_TMP_DIR ;\
-	}
-MOCKERY=$(GOBIN)/mockery
-else
-MOCKERY=$(shell which mockery)
-endif


### PR DESCRIPTION
Does not work reliably and is touching the user system. Added a warning instead.

Here is what happened on my system:

```
...
--2020-09-03 10:33:07--  https://github.com/vektra/mockery/releases/download/v2.0.4/mockery_2.0.4_Linux_x86_64.tar.gz
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/23586998/7fba2180-bfd7-11ea-95aa-f12781cc9471?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T083307Z&X-Amz-Expires=300&X-Amz-Signature=8ac5be6b8066cc57b98b6a93ee5c13e08664f462bfa50680fd8ecb35ddb9d7b8&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=23586998&response-content-disposition=attachment%3B%20filename%3Dmockery_2.0.4_Linux_x86_64.tar.gz&response-content-type=application%2Foctet-stream [following]
--2020-09-03 10:33:07--  https://github-production-release-asset-2e65be.s3.amazonaws.com/23586998/7fba2180-bfd7-11ea-95aa-f12781cc9471?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200903%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200903T083307Z&X-Amz-Expires=300&X-Amz-Signature=8ac5be6b8066cc57b98b6a93ee5c13e08664f462bfa50680fd8ecb35ddb9d7b8&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=23586998&response-content-disposition=attachment%3B%20filename%3Dmockery_2.0.4_Linux_x86_64.tar.gz&response-content-type=application%2Foctet-stream
Resolving github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)... 52.217.10.252
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)|52.217.10.252|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4766068 (4,5M) [application/octet-stream]
Saving to: 'mockery_2.0.4_Linux_x86_64.tar.gz'
mockery_2.0.4_Linux_x86_64.tar.gz                    100%[=====================================================================================================================>]   4,54M  2,35MB/s    in 1,9s    
2020-09-03 10:33:09 (2,35 MB/s) - 'mockery_2.0.4_Linux_x86_64.tar.gz' saved [4766068/4766068]
mv: cannot move 'mockery' to '/mockery': Permission denied
make: *** [Makefile:75: mockery] Error 1
```