### PR TITLE
Don't log grpc health check OK.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -151,7 +151,6 @@ func run() {
 		if err == nil && methodFullName == "/grpc.health.v1.Health/Check" {
 			return false
 		}
-		logger.Info(methodFullName)
 		return true
 	}
 


### PR DESCRIPTION
Calms the logs significantly. Removes these messages:

```
k logs masterdata-api-6674b8cf8f-q8njh
...
{"level":"info","ts":1616162321.3007507,"caller":"zap/options.go:203","msg":"finished unary call with code OK","grpc.start_time":"2021-03-19T13:58:41Z","grpc.request.deadline":"2021-03-19T13:58:42Z","system":"grpc","span.kind":"server","grpc.service":"grpc.health.v1.Health","grpc.method":"Check","peer.address":"127.0.0.1:35314","grpc.code":"OK","grpc.time_ms":0.02199999988079071}
{"level":"info","ts":1616162330.2120845,"caller":"zap/options.go:203","msg":"finished unary call with code OK","grpc.start_time":"2021-03-19T13:58:50Z","grpc.request.deadline":"2021-03-19T13:58:51Z","system":"grpc","span.kind":"server","grpc.service":"grpc.health.v1.Health","grpc.method":"Check","peer.address":"127.0.0.1:35478","grpc.code":"OK","grpc.time_ms":0.02199999988079071}
{"level":"info","ts":1616162331.2891722,"caller":"zap/options.go:203","msg":"finished unary call with code OK","grpc.start_time":"2021-03-19T13:58:51Z","grpc.request.deadline":"2021-03-19T13:58:52Z","system":"grpc","span.kind":"server","grpc.service":"grpc.health.v1.Health","grpc.method":"Check","peer.address":"127.0.0.1:35496","grpc.code":"OK","grpc.time_ms":0.01899999938905239}
{"level":"info","ts":1616162340.2198417,"caller":"zap/options.go:203","msg":"finished unary call with code OK","grpc.start_time":"2021-03-19T13:59:00Z","grpc.request.deadline":"2021-03-19T13:59:01Z","system":"grpc","span.kind":"server","grpc.service":"grpc.health.v1.Health","grpc.method":"Check","peer.address":"127.0.0.1:35628","grpc.code":"OK","grpc.time_ms":0.01899999938905239}
...
```