### PR TITLE
Version grpc client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -128,3 +128,7 @@ func (c GRPCClient) Tenant() v1.TenantServiceClient {
 func (c GRPCClient) TenantMember() v1.TenantMemberServiceClient {
 	return v1.NewTenantMemberServiceClient(c.conn)
 }
+
+func (c GRPCClient) Version() v1.VersionServiceClient {
+	return v1.NewVersionServiceClient(c.conn)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,7 @@ type Client interface {
 	ProjectMember() v1.ProjectMemberServiceClient
 	Tenant() v1.TenantServiceClient
 	TenantMember() v1.TenantMemberServiceClient
+	Version() v1.VersionServiceClient
 	Close() error
 }
 

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -9,14 +9,16 @@ type MockClient struct {
 	tsc  v1.TenantServiceClient
 	pmsc v1.ProjectMemberServiceClient
 	tmsc v1.TenantMemberServiceClient
+	vsc  v1.VersionServiceClient
 }
 
-func NewMock(psc v1.ProjectServiceClient, tsc v1.TenantServiceClient, pmsc v1.ProjectMemberServiceClient, tmsc v1.TenantMemberServiceClient) *MockClient {
+func NewMock(psc v1.ProjectServiceClient, tsc v1.TenantServiceClient, pmsc v1.ProjectMemberServiceClient, tmsc v1.TenantMemberServiceClient, vsc v1.VersionServiceClient) *MockClient {
 	return &MockClient{
 		psc:  psc,
 		tsc:  tsc,
 		pmsc: pmsc,
 		tmsc: tmsc,
+		vsc:  vsc,
 	}
 }
 
@@ -35,4 +37,7 @@ func (c *MockClient) Tenant() v1.TenantServiceClient {
 }
 func (c *MockClient) TenantMember() v1.TenantMemberServiceClient {
 	return c.tmsc
+}
+func (c *MockClient) Version() v1.VersionServiceClient {
+	return c.vsc
 }


### PR DESCRIPTION
## Description
The Version Client is required, so that consumers like metal-api can use the same patterns of queriying information.

Required to merge https://github.com/metal-stack/metal-api/pull/618