### PR TITLE
Fix duplicate memberships in tenant delete

### DIFF
--- a/pkg/service/tenant.go
+++ b/pkg/service/tenant.go
@@ -52,17 +52,17 @@ func (s *tenantService) Update(ctx context.Context, req *v1.TenantUpdateRequest)
 
 func (s *tenantService) Delete(ctx context.Context, req *v1.TenantDeleteRequest) (*v1.TenantResponse, error) {
 	tenant := req.NewTenant()
-	hostFilter := map[string]any{
+	tenantIsHostFilter := map[string]any{
 		"tenantmember ->> 'tenant_id'": tenant.Meta.Id,
 	}
-	memberFilter := map[string]any{
+	tenantIsMemberFilter := map[string]any{
 		"tenantmember ->> 'member_id'": tenant.Meta.Id,
 	}
-	tenantIsHostMemberships, _, err := s.tenantMemberStore.Find(ctx, hostFilter, nil)
+	tenantIsHostMemberships, _, err := s.tenantMemberStore.Find(ctx, tenantIsHostFilter, nil)
 	if err != nil {
 		return nil, err
 	}
-	tenantIsMemberMemberships, _, err := s.tenantMemberStore.Find(ctx, memberFilter, nil)
+	tenantIsMemberMemberships, _, err := s.tenantMemberStore.Find(ctx, tenantIsMemberFilter, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/tenant.go
+++ b/pkg/service/tenant.go
@@ -52,26 +52,32 @@ func (s *tenantService) Update(ctx context.Context, req *v1.TenantUpdateRequest)
 
 func (s *tenantService) Delete(ctx context.Context, req *v1.TenantDeleteRequest) (*v1.TenantResponse, error) {
 	tenant := req.NewTenant()
-	tenantFilter := map[string]any{
+	hostFilter := map[string]any{
 		"tenantmember ->> 'tenant_id'": tenant.Meta.Id,
 	}
 	memberFilter := map[string]any{
 		"tenantmember ->> 'member_id'": tenant.Meta.Id,
 	}
-	tenantMemberships, _, err := s.tenantMemberStore.Find(ctx, tenantFilter, nil)
+	tenantIsHostMemberships, _, err := s.tenantMemberStore.Find(ctx, hostFilter, nil)
 	if err != nil {
 		return nil, err
 	}
-	memberMemberships, _, err := s.tenantMemberStore.Find(ctx, memberFilter, nil)
+	tenantIsMemberMemberships, _, err := s.tenantMemberStore.Find(ctx, memberFilter, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	unionMap := make(map[string]bool)
+	for _, m := range tenantIsHostMemberships {
+		unionMap[m.Meta.Id] = true
+	}
+	for _, m := range tenantIsMemberMemberships {
+		unionMap[m.Meta.Id] = true
+	}
+
 	var ids []string
-	for _, m := range tenantMemberships {
-		ids = append(ids, m.Meta.Id)
-	}
-	for _, m := range memberMemberships {
-		ids = append(ids, m.Meta.Id)
+	for k := range unionMap {
+		ids = append(ids, k)
 	}
 
 	if len(ids) > 0 {

--- a/pkg/service/tenant_test.go
+++ b/pkg/service/tenant_test.go
@@ -112,8 +112,25 @@ func TestDeleteTenant(t *testing.T) {
 	var paging *v1.Paging
 
 	storageMock.On("Delete", ctx, t3.Meta.Id).Return(nil)
-	memberStorageMock.On("Find", ctx, tfilter, paging).Return([]*v1.TenantMember{}, nil, nil)
-	memberStorageMock.On("Find", ctx, mfilter, paging).Return([]*v1.TenantMember{}, nil, nil)
+	memberStorageMock.On("Find", ctx, tfilter, paging).Return([]*v1.TenantMember{
+		{
+			Meta: &v1.Meta{
+				Id: "t3",
+			},
+			TenantId: t3.Meta.Id,
+			MemberId: t3.Meta.Id,
+		},
+	}, nil, nil)
+	memberStorageMock.On("Find", ctx, mfilter, paging).Return([]*v1.TenantMember{
+		{
+			Meta: &v1.Meta{
+				Id: "t3",
+			},
+			TenantId: t3.Meta.Id,
+			MemberId: t3.Meta.Id,
+		},
+	}, nil, nil)
+	memberStorageMock.On("DeleteAll", ctx, "t3").Return(nil)
 	resp, err := ts.Delete(ctx, tdr)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)


### PR DESCRIPTION
## Description

There is a bug in the tenant delete method. A tenant is always member of their own tenant. So when the memberships are cleaned up this membership is found twice, because we are searching for memberships where a tenant is member of another tenant and for those where someone else is member of the tenant. Then we try to delete the same membership twice which results in a data corruption error. This PR fixes the issue.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
