### PR TITLE
Fix global variable logger not initialized.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -104,7 +104,7 @@ func run() error {
 	}
 	jsonHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl, AddSource: false})
 
-	logger := slog.New(jsonHandler)
+	logger = slog.New(jsonHandler)
 
 	port := viper.GetInt("port")
 	addr := fmt.Sprintf(":%d", port)


### PR DESCRIPTION
## Description

```
 panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6987b8]

goroutine 1 [running]:
log/slog.(*Logger).Handler(...)
	/opt/hostedtoolcache/go/1.25.1/x64/src/log/slog/logger.go:121
log/slog.(*Logger).Enabled(0x4a263a?, {0x1005798?, 0x16f2860?}, 0xc000111bc0?)
	/opt/hostedtoolcache/go/1.25.1/x64/src/log/slog/logger.go:168 +0x18
log/slog.(*Logger).log(0x0, {0x1005798?, 0x16f2860?}, 0x8, {0xebce27, 0x1d}, {0xc000111f20, 0x2, 0x2})
	/opt/hostedtoolcache/go/1.25.1/x64/src/log/slog/logger.go:244 +0x99
log/slog.(*Logger).Error(...)
	/opt/hostedtoolcache/go/1.25.1/x64/src/log/slog/logger.go:229
main.main()
	/home/runner/work/masterdata-api/masterdata-api/server/main.go:66 +0x93 
Recent samples Learn more 
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
